### PR TITLE
Add `git-mirror-docker` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ GitLab install.
 
 It's small enough to audit, easy enough to write a SysV service file
 for, or a SystemD service file, and you don't need to buy GitLab EE!
+
+There is also a Docker image available, if you want to configure
+`git-mirror` alongside your existing `gitlab-ce` and `gitlab-runner`
+Docker images: [`git-mirror-docker`][git-mirror-docker]
+
+[git-mirror-docker]: https://github.com/flotwig/git-mirror-docker


### PR DESCRIPTION
Awesome tool! I'm using this project now to automatically trigger GitLab CI for GitHub projects.

I created a Docker image to make this easier to deploy and thought you might want to know/share it in your README, so here you go.